### PR TITLE
fix deprecation warning

### DIFF
--- a/ecs-cluster/iam.tf
+++ b/ecs-cluster/iam.tf
@@ -5,7 +5,7 @@
 
 resource "aws_iam_instance_profile" "ecs-instance-profile" {
     name = "ecs-instance-profile-${terraform.env}"
-    roles = ["${aws_iam_role.ecs-instance-role.name}"]
+    role = "${aws_iam_role.ecs-instance-role.name}"
 }
 
 resource "aws_iam_role" "ecs-instance-role" {


### PR DESCRIPTION
"roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile