### PR TITLE
Move vars to the correct place, use lower bound 0 with upscale

### DIFF
--- a/scaling/main.tf
+++ b/scaling/main.tf
@@ -51,7 +51,7 @@ resource "aws_appautoscaling_policy" "scale_down" {
   service_namespace       = "ecs"
 
   step_adjustment {
-    metric_interval_upper_bound = "${var.lowerbound}"
+    metric_interval_upper_bound = "${var.upperbound}"
     scaling_adjustment          = "${var.scale_down_adjustment}"
   }
 
@@ -68,7 +68,7 @@ resource "aws_appautoscaling_policy" "scale_up" {
   service_namespace       = "ecs"
 
   step_adjustment {
-    metric_interval_upper_bound = "${var.upperbound}"
+    metric_interval_lower_bound = "${var.lowerbound}"
     scaling_adjustment          = "${var.scale_up_adjustment}"
   }
 


### PR DESCRIPTION
- Use the correct vars on the correct places
- Use the lowerbound for the upscale

See https://skyscrapers.slack.com/archives/C4H8URNKA/p1504610621000321