### PR TITLE
adding instance profile arn as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Setup a basic ECS cluster with the needed IAM rights.
  * [`cluster_name`]: String: The name of the ECS cluster.
  * [`cluster_id`]: String: The ID (ARN) of the ECS cluster.
  * [`ecs-instance-profile`]: IAM instance profile that you need to give to your instances.
+ * [`ecs_instance_profile_arn`]: IAM instance profile arn that you need to give to your instances.
  * [`ecs-service-role`]: IAM service role for ECS to manage your loadbalancers
  * [`ecs-instance-role`]: IAM instance role name, useful to attach extra policies
 
@@ -109,7 +110,7 @@ module "service-scaling" {
 }
 ```
 
-## CI/CD 
+## CI/CD
 
 In the `ci` folder you can find some tasks definition for automating deployment with `concourse`
 

--- a/ecs-cluster/outputs.tf
+++ b/ecs-cluster/outputs.tf
@@ -10,6 +10,10 @@ output "ecs-instance-profile" {
   value = "${aws_iam_instance_profile.ecs-instance-profile.name}"
 }
 
+output "ecs_instance_profile_arn" {
+  value = "${aws_iam_instance_profile.ecs-instance-profile.arn}"
+}
+
 output "ecs-service-role" {
   value = "${aws_iam_role.ecs-service-role.name}"
 }


### PR DESCRIPTION
The instance profile ARN can be handy for example for spot instances requests.