### PR TITLE
IAM role name change

### DIFF
--- a/scaling/iam.tf
+++ b/scaling/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs-autoscale-role" {
-  name = "ecs-scale-${terraform.env}-${var.cluster_name}-${var.service_name}"
+  name = "ecs-scale-${var.cluster_name}-${var.service_name}"
 
   assume_role_policy = <<EOF
 {


### PR DESCRIPTION
IAM role name here is too long, making it exceed the limit of 64 characters easily.
So I removed the env part of the name, as probably it'll be already included if not in the service name then in the cluster name