### PR TITLE
adding user-data creation to the ecs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Setup a ECS cluster and service scaling.
  * [`datapoints_to_alarm_up`]: String(optional): ) The number of datapoints that must be breaching to trigger the alarm to scale up (default: 4)
  * [`datapoints_to_alarm_down`]: String(optional): The number of datapoints that must be breaching to trigger the alarm to scale down (default: 4)
 
+
 ### Output
 
 ### Example
@@ -107,6 +108,32 @@ module "service-scaling" {
   min_capacity             = "2"
   max_capacity             = "10"
   ecs_autoscale_group_name = "asg-production"
+}
+```
+
+## user-data
+Setup a ECS cluster and service user-data.
+
+### Available variables:
+ * [`project`]: String(optional): The project to tag EFS (default: "")
+ * [`environment`]: String(required):  For what environment is this cluster needed (eg staging, production, ...)
+ * [`cluster_name`]: String(required): The name of the ECS cluster.
+ * [`teleport_version`]: String(required): The version of Teleport to be used (default: 2.5.8).
+ * [`teleport_server`]: String(optional): the name of the teleport server to connect to(default: "")
+ * [`teleport_auth_token`]: String(optional): Teleport server node token (default: "")
+
+### Output
+
+### Example
+```
+module "service-user-data" {
+  source                   = "user-data"
+  project             = "${var.project}"
+  environment         = "${terraform.workspace}"
+  teleport_auth_token = "${data.aws_kms_secret.secret.auth_token}"
+  teleport_version    = "${var.teleport_version}"
+  teleport_server     = "${var.teleport_server}"
+  cluster_name        = "${module.ecs_cluster.cluster_name}"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Setup a ECS cluster and service user-data.
  * [`project`]: String(optional): The project to tag EFS (default: "")
  * [`environment`]: String(required):  For what environment is this cluster needed (eg staging, production, ...)
  * [`cluster_name`]: String(required): The name of the ECS cluster.
- * [`teleport_version`]: String(required): The version of Teleport to be used (default: 2.5.8).
+ * [`teleport_version`]: String(optional): The version of Teleport to be used (default: 2.5.8).
  * [`teleport_server`]: String(optional): the name of the teleport server to connect to(default: "")
  * [`teleport_auth_token`]: String(optional): Teleport server node token (default: "")
 

--- a/user-data/main.tf
+++ b/user-data/main.tf
@@ -1,0 +1,61 @@
+data "template_cloudinit_config" "teleport_bootstrap" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    content      = "package_update: true"
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = "package_upgrade: true"
+  }
+
+  part {
+    content_type = "text/cloud-config"
+
+    content = <<EOF
+write_files:
+${module.teleport_bootstrap_script.teleport_config_cloudinit}
+${module.teleport_bootstrap_script.teleport_service_cloudinit}
+EOF
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+
+    content = <<EOF
+#!/bin/bash
+cd /tmp
+curl -L "https://get.gravitational.com/teleport-v${var.teleport_version}-linux-amd64-bin.tar.gz" > ./teleport.tar.gz
+sudo tar -xzf ./teleport.tar.gz
+sudo ./teleport/install
+
+# Prevent containers that use the bridge network mode from accessing the
+# credential information supplied to the container instance profile.
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+iptables --insert FORWARD 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP
+service iptables save
+
+echo ECS_CLUSTER=${var.cluster_name} >> /etc/ecs/ecs.config
+start ecs
+EOF
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+
+    content = "${module.teleport_bootstrap_script.teleport_bootstrap_script}"
+  }
+}
+
+module "teleport_bootstrap_script" {
+  source       = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=3.2.0"
+  auth_server  = "${var.teleport_server}"
+  auth_token   = "${var.teleport_auth_token}"
+  function     = "ecs"
+  environment  = "${var.environment}"
+  project      = "${var.project}"
+  service_type = "upstart"
+}

--- a/user-data/outputs.tf
+++ b/user-data/outputs.tf
@@ -1,0 +1,3 @@
+output "userdata" {
+  value = "${data.template_cloudinit_config.teleport_bootstrap.rendered}"
+}

--- a/user-data/variables.tf
+++ b/user-data/variables.tf
@@ -1,0 +1,15 @@
+variable "environment" {}
+variable "project" {}
+variable "cluster_name" {}
+
+variable "teleport_version" {
+  default = "2.5.8"
+}
+
+variable "teleport_server" {
+  default = ""
+}
+
+variable "teleport_auth_token" {
+  default = ""
+}


### PR DESCRIPTION
This PR allows to add the user-data creation functionality to this module.
This will allow us to just add this module to be able to setup the cluster and teleport (if needed).
NOTE: teleport is not mandatory as some cluster still don't have that.

Tested in SAP staging