### PR TITLE
fixes alertmanager slack username

### DIFF
--- a/monitoring/templates/alertmanager.yml
+++ b/monitoring/templates/alertmanager.yml
@@ -22,7 +22,8 @@ route:
 receivers:
   - name: 'slack'
     slack_configs:
-      - send_resolved: true
+      - username: ${project}-${environment}-ecs
+        send_resolved: true
         channel: '${slack_channel}'
   - name: 'opsgenie'
     opsgenie_configs:


### PR DESCRIPTION
This PR specifies a default username for slack notification based on environment and project