### PR TITLE
Set minimum health percent to 0 for prometheus

### DIFF
--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -80,6 +80,11 @@ resource "aws_ecs_service" "monitoring" {
   desired_count   = "${var.desired_count}"
   iam_role        = "${var.ecs_service_role}"
 
+  # In the current setup, Prometheus uses a single efs file system,
+  # which means that there can only be one Prometheus container running
+  # simultaneously in the cluster.
+  deployment_minimum_healthy_percent = 0
+
   ordered_placement_strategy {
     type  = "spread"
     field = "host"

--- a/monitoring/main.tf
+++ b/monitoring/main.tf
@@ -80,7 +80,8 @@ resource "aws_ecs_service" "monitoring" {
   desired_count   = "${var.desired_count}"
   iam_role        = "${var.ecs_service_role}"
 
-  # In the current setup, Prometheus uses a single efs file system,
+  # In the current setup, Prometheus uses a single EFS file system
+  # across the entire ECS cluster, and it locks it via a lock-file,
   # which means that there can only be one Prometheus container running
   # simultaneously in the cluster.
   deployment_minimum_healthy_percent = 0


### PR DESCRIPTION

In the current setup, Prometheus uses a single efs file system, which means that there can only be one Prometheus container running simultaneously in the cluster.

Without this the rolling updates don't work because ECS cannot drain the node where Prometheus is working